### PR TITLE
Include pyservice and ubuntu base images to offline installers

### DIFF
--- a/installers/community/arm64/lc-agent/.env
+++ b/installers/community/arm64/lc-agent/.env
@@ -1,6 +1,9 @@
 LABS_AIR_VERSION=0.7.0
+UBUNTU_VERSION=18.04
 COMPOSE_HTTP_TIMEOUT=200
 LC_HOME=~
 ServiceLocatorPort=5408
 ServiceLocatorIP=localhost
 AgentID=must_set_your_unique_id
+
+

--- a/installers/community/arm64/lc-agent/export.sh
+++ b/installers/community/arm64/lc-agent/export.sh
@@ -7,3 +7,7 @@ source .env
 docker-compose pull || exit 1
 
 docker save --output "./archives/labs-lightcrane-agent-arm64:${LABS_AIR_VERSION}.tar" "public.ecr.aws/tibcolabs/labs-lightcrane-agent-arm64:${LABS_AIR_VERSION}" || exit 1
+
+docker save --output "./archives/labs-lightcrane-pyservice-base-arm64:${LABS_AIR_VERSION}.tar" "public.ecr.aws/tibcolabs/labs-lightcrane-pyservice-base-arm64:${LABS_AIR_VERSION}" || exit 1
+
+docker save --output "./archives/ubuntu:${UBUNTU_VERSION}.tar" "ubuntu:${UBUNTU_VERSION}" || exit 1

--- a/installers/community/arm64/lc-agent/load.sh
+++ b/installers/community/arm64/lc-agent/load.sh
@@ -4,3 +4,7 @@
 source .env
 
 docker load --input "./archives/labs-lightcrane-agent-arm64:${LABS_AIR_VERSION}.tar" || exit 1
+
+docker load --input "./archives/labs-lightcrane-pyservice-base-arm64:${LABS_AIR_VERSION}.tar" || exit 1
+
+docker load --input "./archives/ubuntu:${UBUNTU_VERSION}.tar" || exit 1


### PR DESCRIPTION
# Story

Include 2 new images to offline installers, python service and ubuntu base.

## Changes

1. Add python service image
2. add ubuntu base image

## Tests

Tested locally.
