### PR TITLE
Add lightcrane agent to amd64

### DIFF
--- a/installers/community/amd64/lc-agent/.env
+++ b/installers/community/amd64/lc-agent/.env
@@ -1,1 +1,11 @@
+UBUNTU_VERSION=18.04
+COMPOSE_HTTP_TIMEOUT=200
+LC_HOME=~
+ServiceLocatorPort=5408
+ServiceLocatorIP=localhost
+AgentID=must_set_your_unique_id
 LABS_AIR_VERSION=GENERATED_VERSION
+
+
+
+

--- a/installers/community/amd64/lc-agent/docker-compose.yml
+++ b/installers/community/amd64/lc-agent/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.7'
+services:
+  agent:
+    image: public.ecr.aws/tibcolabs/labs-lightcrane-agent:${LABS_AIR_VERSION}
+    container_name: agent
+    restart: always
+    ports:
+      - '10082:10082'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${LC_HOME}:/home/f1
+    environment:
+      - FLOGO_APP_PROPS_ENV=auto
+      - System_BaseFolder=/home/f1
+      - System_BaseFolderExt=${LC_HOME}
+      - System_ServiceLocatorIP=${ServiceLocatorIP}
+      - System_ServiceLocatorPort=${ServiceLocatorPort}
+      - System_Network=light_crane
+      - System_AgentID=${AgentID}
+
+networks:
+  default:
+    name: light_crane

--- a/installers/community/amd64/lc-agent/export.sh
+++ b/installers/community/amd64/lc-agent/export.sh
@@ -1,1 +1,15 @@
 #!/bin/bash
+mkdir -p ./archives
+
+# shellcheck source=.env
+source .env
+
+docker-compose pull || exit 1
+
+docker save --output "./archives/labs-lightcrane-agent:${LABS_AIR_VERSION}.tar" "public.ecr.aws/tibcolabs/labs-lightcrane-agent:${LABS_AIR_VERSION}" || exit 1
+
+docker pull public.ecr.aws/tibcolabs/labs-lightcrane-pyservice-base:${LABS_AIR_VERSION}
+docker save --output "./archives/labs-lightcrane-pyservice-base:${LABS_AIR_VERSION}.tar" "public.ecr.aws/tibcolabs/labs-lightcrane-pyservice-base:${LABS_AIR_VERSION}" || exit 1
+
+docker pull ubuntu:${UBUNTU_VERSION}
+docker save --output "./archives/ubuntu:${UBUNTU_VERSION}.tar" "ubuntu:${UBUNTU_VERSION}" || exit 1

--- a/installers/community/amd64/lc-agent/load.sh
+++ b/installers/community/amd64/lc-agent/load.sh
@@ -1,1 +1,10 @@
 #!/bin/bash
+
+# shellcheck source=.env
+source .env
+
+docker load --input "./archives/labs-lightcrane-agent:${LABS_AIR_VERSION}.tar" || exit 1
+
+docker load --input "./archives/labs-lightcrane-pyservice-base:${LABS_AIR_VERSION}.tar" || exit 1
+
+docker load --input "./archives/ubuntu:${UBUNTU_VERSION}.tar" || exit 1

--- a/installers/community/amd64/lc-agent/start.sh
+++ b/installers/community/amd64/lc-agent/start.sh
@@ -1,1 +1,5 @@
 #!/bin/bash
+
+docker-compose rm -f
+
+docker-compose up -d --build

--- a/installers/community/amd64/lc-agent/stop.sh
+++ b/installers/community/amd64/lc-agent/stop.sh
@@ -1,1 +1,2 @@
 #!/bin/bash
+docker-compose down


### PR DESCRIPTION
# Story

Add lightcrane agent to amd64

## Changes

1. Add docker-compose to lightcrane agent
2. change start.sh and stop.sh

## Tests

Tested locally.
