### PR TITLE
Updated windows scripts

### DIFF
--- a/installers/community/lc-backend/start.cmd
+++ b/installers/community/lc-backend/start.cmd
@@ -8,7 +8,7 @@ if not exist "%LC_HOME%" mkdir "%LC_HOME%"
 @REM if "%1%"=="amd64"  set ARCH=""
 @REM if "%1%"=="arm64"  set ARCH="-arm64"
 
-set ARCH=""
+set ARCH=
 
 docker-compose rm -f
 docker-compose up -d

--- a/installers/community/lc-backend/stop.cmd
+++ b/installers/community/lc-backend/stop.cmd
@@ -2,7 +2,7 @@
 
 set LC_HOME=./LC
 
-set ARCH=""
+set ARCH=
 
 @REM if "%1%"==""  set ARCH=""
 @REM if "%1%"=="amd64"  set ARCH=""


### PR DESCRIPTION

# Story

Updated windows scripts to use empty string instead of empty double quotes

## Changes

1. Updated lc-backend/start.cmd
2. Updated lc-backend/stop.cmd

## Tests

NA
